### PR TITLE
Set default node shape

### DIFF
--- a/server.py
+++ b/server.py
@@ -4,6 +4,10 @@ import asyncio
 import traceback
 
 import nodes
+
+# Default shape for new nodes sent to the frontend. Can be overridden with
+# the COMFYUI_DEFAULT_NODE_SHAPE environment variable.
+DEFAULT_NODE_SHAPE = os.getenv("COMFYUI_DEFAULT_NODE_SHAPE", "box")
 import folder_paths
 import execution
 import uuid
@@ -618,6 +622,11 @@ class PromptServer():
 
             if hasattr(obj_class, 'API_NODE'):
                 info['api_node'] = obj_class.API_NODE
+
+            # Node shape is used by the frontend to style nodes. If the node
+            # class doesn't define a specific shape, fall back to the global
+            # default.
+            info['shape'] = getattr(obj_class, 'SHAPE', DEFAULT_NODE_SHAPE)
             return info
 
         @routes.get("/object_info")

--- a/tests-unit/server/object_info_shape_test.py
+++ b/tests-unit/server/object_info_shape_test.py
@@ -1,0 +1,31 @@
+import types
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+@pytest.mark.asyncio
+async def test_object_info_default_shape(aiohttp_client):
+    # Create a dummy nodes module with a single node
+    dummy_nodes = types.ModuleType('nodes')
+
+    class DummyNode:
+        @classmethod
+        def INPUT_TYPES(cls):
+            return {"required": {}}
+        RETURN_TYPES = ()
+
+    dummy_nodes.NODE_CLASS_MAPPINGS = {"DummyNode": DummyNode}
+    dummy_nodes.NODE_DISPLAY_NAME_MAPPINGS = {}
+
+    with patch.dict('sys.modules', {'nodes': dummy_nodes}):
+        from server import PromptServer, DEFAULT_NODE_SHAPE
+        from app.frontend_management import FrontendManager
+
+        with patch.object(FrontendManager, 'init_frontend', return_value='webroot'):
+            srv = PromptServer(asyncio.get_event_loop())
+            client = await aiohttp_client(srv.app)
+            resp = await client.get('/object_info/DummyNode')
+            assert resp.status == 200
+            data = await resp.json()
+            assert data['DummyNode']['shape'] == DEFAULT_NODE_SHAPE


### PR DESCRIPTION
## Summary
- set a global default node shape
- expose node shape info via server object_info
- test object_info provides shape

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_687125a92e30832db769207a05968b93

## Summary by Sourcery

Include node shape metadata in the server’s object_info response, falling back to a global default, and add a unit test to verify the default shape behavior.

New Features:
- Expose a "shape" field in the /object_info endpoint for each node, defaulting to DEFAULT_NODE_SHAPE when not explicitly defined.

Tests:
- Add an async unit test to verify that /object_info returns the default node shape for nodes without a custom SHAPE attribute.